### PR TITLE
added_workflow & kind workflow port

### DIFF
--- a/minikube/cluster-config.yaml
+++ b/minikube/cluster-config.yaml
@@ -24,6 +24,9 @@ nodes:
   - containerPort: 30443
     hostPort: 30443
     protocol: TCP
+  - containerPort: 32746
+    hostPort: 32746
+    protocol: TCP    
 - role: worker
   labels:
     node-type: worker-1


### PR DESCRIPTION

- Improved the Argo Workflows installation script to:
  - Wait for the `argo-server` deployment to be ready before proceeding.
  - Set Argo Workflows authentication mode to `server` 
  - Added idempotent creation of the `argo-default-admin` rolebinding (skips creation if it already exists).
  - Patched the `argo-server` service to use NodePort 32746 for easier UI access from the host.
- Updated instructions and script output to guide users on accessing the Argo Workflows UI and handling RBAC.

These changes make the setup more robust, user-friendly, and suitable for repeated use in exam/lab environments.